### PR TITLE
Alper/eng 5220 error opening annotations in label studio

### DIFF
--- a/label_studio/core/settings/label_studio.py
+++ b/label_studio/core/settings/label_studio.py
@@ -8,7 +8,7 @@ from core.utils.secret_key import generate_secret_key_if_missing
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = generate_secret_key_if_missing(BASE_DATA_DIR)
 
-DJANGO_DB = get_env('DJANGO_DB', DJANGO_DB_SQLITE)
+DJANGO_DB = get_env('DJANGO_DB', DJANGO_DB_POSTGRESQL)
 DATABASES = {'default': DATABASES_ALL[DJANGO_DB]}
 
 MIDDLEWARE.append('organizations.middleware.DummyGetSessionMiddleware')

--- a/label_studio/core/wsgi.py
+++ b/label_studio/core/wsgi.py
@@ -5,6 +5,7 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'khan.settings.prod')
+# os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'khan.settings.prod')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'core.settings')
 
 application = get_wsgi_application()

--- a/label_studio/khan/settings/base.py
+++ b/label_studio/khan/settings/base.py
@@ -6,11 +6,6 @@ from core.utils.secret_key import generate_secret_key_if_missing
 
 SECRET_KEY = generate_secret_key_if_missing(BASE_DATA_DIR)
 
-# Make sure our custom django app is installed
-INSTALLED_APPS.extend([
-    "khan",
-    "khan.rbac"
-])
 
 # Add our Rules Permissions Class to drf permissions classes so our
 # custom RBAC works

--- a/label_studio/manage.py
+++ b/label_studio/manage.py
@@ -5,7 +5,8 @@ import os
 import sys
 
 if __name__ == '__main__':
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'khan.settings.prod')
+    # os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'khan.settings.prod')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'core.settings.label_studio')
     # os.environ.setdefault('DEBUG', 'True')
     try:
         from django.conf import settings

--- a/label_studio/server.py
+++ b/label_studio/server.py
@@ -36,7 +36,8 @@ DEFAULT_USERNAME = 'default_user@localhost'
 
 def _setup_env():
     sys.path.insert(0, LS_PATH)
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'khan.settings.prod')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'label_studio.core.settings.label_studio')
+    # os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'khan.settings.prod')
     get_wsgi_application()
 
 


### PR DESCRIPTION
This has been the weirdest journey. Frontend wasn't the issue, backend was and I have no clue how this fixes the problem. Short explanation; this PR somehow fixes the problems. Here's the longer one:

I switched to 1.13.1 and everything worked. I tried copying our code to 1.13.1 and when i switched to khan django settings file Computer Vision UI stopped working with the same error. Why? I have no clue. So I switched back to core, copied everything from khan to core and just used that one, and everything works!

So i did following tests for infra.
- Created a new db for it and made the new image run against it. It created tables without any issue.
- I created another table and run our pg.dump against it, pointed the image to it and it works.

So I created a new user, made a new project to test both AddressManager and the UI you provided me, both work. So I did the following tests.

- Created a new project with the labeling config you provided and could see the config without any issues.
- I tried it without the completed annotation but with the image you provided. I draw annotation boxes on it and could complete the annotation.

I couldnt really test the already completed one you provided because label-studio attaches uploads and annotations with project ids so i couldnt get it to work. If this is a necessary step before merging let me know and i'll look more into it.